### PR TITLE
Fix React not in scope and http-only bugs

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,3 +1,4 @@
+import React from "react";
 import Posts from "./Components/Posts";
 import PostForm from "./Components/PostForm";
 import { useEffect, createContext, useReducer } from "react";

--- a/src/Components/PostForm.js
+++ b/src/Components/PostForm.js
@@ -1,3 +1,4 @@
+import React from "react";
 import "../CSS/PostForm.css";
 import { useState, useContext } from "react";
 import { AppContext } from "../App";

--- a/src/Components/Posts.js
+++ b/src/Components/Posts.js
@@ -1,3 +1,4 @@
+import React from "react";
 import "../CSS/Post.css";
 import { useEffect, useContext } from "react";
 import { AppContext } from "../App";
@@ -6,7 +7,7 @@ const Posts = () => {
   const [state, dispatch] = useContext(AppContext);
 
   useEffect(() => {
-    fetch("http://jsonplaceholder.typicode.com/posts")
+    fetch("https://jsonplaceholder.typicode.com/posts")
       .then((res) => res.json())
       .then((posts) => {
         dispatch({ type: "FETCH_POSTS", payload: posts });


### PR DESCRIPTION
Thanks for the Medium article. I found the following 'bugs' by trying to run e.g. https://codesandbox.io/s/github/patwadeepak/blog-app-react-3-different-ways/tree/usingContext&Hooks

React needs to be in scope
The typicode fixture docs need to be loaded via HTTPS (at least in chrome)